### PR TITLE
Prevent error if instance is nil on client (StreamingEnabled support)

### DIFF
--- a/ReplicatedTweening.lua
+++ b/ReplicatedTweening.lua
@@ -176,6 +176,11 @@ if rService:IsClient() then -- OnClientEvent only works clientside
 	local runningTweens = {}
 
 	tEvent.OnClientEvent:Connect(function(purpose, instance, tInfo, propertyTable)
+			if instance == nil then
+				warn("Ignored tween request because instance is nil")
+				return -- prevent error if client is unaware of target instance.
+			end
+
 			if tInfo ~= nil then
 				tInfo = Table_To_TweenInfo(tInfo)
 			end


### PR DESCRIPTION
This change will prevent an error on the client if the target instance of a tween isn't present.
This means there won't be an error if the server tweens a part which is out of a client's streaming range.